### PR TITLE
feat(japan-dc-support): add japan region support

### DIFF
--- a/logs-function/go.mod
+++ b/logs-function/go.mod
@@ -4,7 +4,7 @@ go 1.24.6
 
 require (
 	github.com/fnproject/fdk-go v0.0.60
-	github.com/newrelic/newrelic-client-go/v2 v2.44.0
+	github.com/newrelic/newrelic-client-go/v2 v2.83.3
 	github.com/oracle/oci-go-sdk/v65 v65.96.0
 	github.com/sirupsen/logrus v1.9.3
 	github.com/stretchr/testify v1.9.0

--- a/logs-function/go.sum
+++ b/logs-function/go.sum
@@ -23,8 +23,8 @@ github.com/mattn/go-colorable v0.1.13 h1:fFA4WZxdEF4tXPZVKMLwD8oUnCTTo08duU7wxec
 github.com/mattn/go-colorable v0.1.13/go.mod h1:7S9/ev0klgBDR4GtXTXX8a3vIGJpMovkB8vQcUbaXHg=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
-github.com/newrelic/newrelic-client-go/v2 v2.44.0 h1:n4zP64Hfui8pjW/D3tbE1Hi+Acbpz8nBIrI2miEAGiI=
-github.com/newrelic/newrelic-client-go/v2 v2.44.0/go.mod h1:pDFY24/6iIMEbPIdowTRrRn9YYwkXc3j+B+XpTb4oF4=
+github.com/newrelic/newrelic-client-go/v2 v2.83.3 h1:K7ZICbj40uBSjwf8L2XpqBlYV9oqb95jV9HxWWC6Wfs=
+github.com/newrelic/newrelic-client-go/v2 v2.83.3/go.mod h1:kROngr/zeNyxbdOI3zPK4Al+ze32XjLEVUDzjxsKW9g=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e h1:fD57ERR4JtEqsWbfPhv4DMiApHyliiK5xCTNVSPiaAs=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/oracle/oci-go-sdk/v65 v65.96.0 h1:ew0WavsB6N/I6etYCC160cD5qDXbek/1xZgujqTzork=

--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -49,6 +49,7 @@ locals {
   newrelic_graphql_endpoint = {
     US = "https://api.newrelic.com/graphql"
     EU = "https://api.eu.newrelic.com/graphql"
+    JP = "https://api.jp.newrelic.com/graphql"
   }[var.new_relic_region]
   updateLinkAccount_graphql_query = <<EOF
 mutation {

--- a/terraform/schema.yaml
+++ b/terraform/schema.yaml
@@ -54,13 +54,14 @@ variables:
 
   new_relic_region:
     type: enum
-    title: "New Relic Region. US or EU"
-    description: "Datacenter where the data will be sent (US/EU)"
+    title: "New Relic Region. US, EU, or JP"
+    description: "Datacenter where the data will be sent (US/EU/JP)"
     required: true
     default: "US"
     enum:
       - "US"
       - "EU"
+      - "JP"
 
   newrelic_account_id:
     type: string

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -22,7 +22,7 @@ variable "region" {
 variable "new_relic_region" {
   type        = string
   default     = "US"
-  description = "New Relic Region. US or EU"
+  description = "New Relic Region. US, EU, or JP"
 }
 
 variable "newrelic_account_id" {


### PR DESCRIPTION
**Summary**
Adds support for the New Relic Japan (JP) region alongside the existing US and EU regions, enabling OCI log forwarding to https://api.jp.newrelic.com/graphql. Also upgrades the newrelic-client-go dependency to v2.83.3 which includes JP region support.


**How to use**

Set new_relic_region to "JP" in your Terraform variables or select "JP" from the OCI Resource Manager dropdown when deploying.

**Testing**

terraform validate — Terraform configuration validates successfully
Ran this test to check if NRClient is able to initialise with jp region

```
go test -run TestNewNRClient -v ./util/
```