### PR TITLE
fix: upgrade nr go client version to use correct logs endpoint

### DIFF
--- a/logs-function/go.mod
+++ b/logs-function/go.mod
@@ -4,7 +4,7 @@ go 1.24.6
 
 require (
 	github.com/fnproject/fdk-go v0.0.60
-	github.com/newrelic/newrelic-client-go/v2 v2.83.3
+	github.com/newrelic/newrelic-client-go/v2 v2.86.1
 	github.com/oracle/oci-go-sdk/v65 v65.96.0
 	github.com/sirupsen/logrus v1.9.3
 	github.com/stretchr/testify v1.9.0

--- a/logs-function/go.sum
+++ b/logs-function/go.sum
@@ -23,8 +23,8 @@ github.com/mattn/go-colorable v0.1.13 h1:fFA4WZxdEF4tXPZVKMLwD8oUnCTTo08duU7wxec
 github.com/mattn/go-colorable v0.1.13/go.mod h1:7S9/ev0klgBDR4GtXTXX8a3vIGJpMovkB8vQcUbaXHg=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
-github.com/newrelic/newrelic-client-go/v2 v2.83.3 h1:K7ZICbj40uBSjwf8L2XpqBlYV9oqb95jV9HxWWC6Wfs=
-github.com/newrelic/newrelic-client-go/v2 v2.83.3/go.mod h1:kROngr/zeNyxbdOI3zPK4Al+ze32XjLEVUDzjxsKW9g=
+github.com/newrelic/newrelic-client-go/v2 v2.86.1 h1:B9hpEyRU6t70lnlNV6bO0wF9nvGw660fjFoAk28NdCs=
+github.com/newrelic/newrelic-client-go/v2 v2.86.1/go.mod h1:kROngr/zeNyxbdOI3zPK4Al+ze32XjLEVUDzjxsKW9g=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e h1:fD57ERR4JtEqsWbfPhv4DMiApHyliiK5xCTNVSPiaAs=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/oracle/oci-go-sdk/v65 v65.96.0 h1:ew0WavsB6N/I6etYCC160cD5qDXbek/1xZgujqTzork=


### PR DESCRIPTION
**Summary**
Bumped the newrelic-client-go dependency to v2.86.1 to use the correct logs JP endpoint.

**How to use**

Set new_relic_region to "JP" in your Terraform variables or select "JP" from the OCI Resource Manager dropdown when deploying.

**Testing**

terraform validate — Terraform configuration validates successfully
Ran this test to check if NRClient is able to initialise with jp region

`go test -run TestNewNRClient -v ./util/`