### PR TITLE
fix: upgrade Go to 1.25.9 to address 9 CVE vulnerabilities

### DIFF
--- a/logs-function/Dockerfile
+++ b/logs-function/Dockerfile
@@ -14,7 +14,7 @@ COPY . .
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o function main.go
 
 # Final stage: minimal image for OCI Functions
-FROM fnproject/go:1.25
+FROM fnproject/go:1.24
 
 WORKDIR /function
 

--- a/logs-function/Dockerfile
+++ b/logs-function/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage: compile Go binary
-FROM golang:1.24.6 AS build-stage
+FROM golang:1.25.9 AS build-stage
 
 WORKDIR /function
 
@@ -14,7 +14,7 @@ COPY . .
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o function main.go
 
 # Final stage: minimal image for OCI Functions
-FROM fnproject/go:1.24
+FROM fnproject/go:1.25
 
 WORKDIR /function
 

--- a/logs-function/go.mod
+++ b/logs-function/go.mod
@@ -1,6 +1,6 @@
 module github.com/newrelic/oci-log-integration/logs-function
 
-go 1.24.6
+go 1.25.9
 
 require (
 	github.com/fnproject/fdk-go v0.0.60


### PR DESCRIPTION
## Summary
Upgrades Go from 1.24.6 to 1.25.9 to fix all 9 outstanding CodeQL-reported CVE vulnerabilities in the Go standard library.

## Changes
- Updated `go.mod` to Go 1.25.9
- Updated `Dockerfile` build stage to `golang:1.25.9`
- Updated `Dockerfile` final stage to `fnproject/go:1.25`

## CVE Vulnerabilities Fixed

This PR addresses all 9 CVE vulnerabilities:

| Ticket | CVE | Package | Severity | Fix Version |
|--------|-----|---------|----------|-------------|
| NR-560535 | CVE-2025-58183 | archive/tar | High | 1.24.8+, 1.25.2+ |
| NR-560533 | CVE-2025-68121 | crypto/tls | **Critical** | 1.24.13+, 1.25.7+ |
| NR-560532 | CVE-2025-61726 | net/url | High | 1.24.12+, 1.25.6+ |
| NR-560531 | CVE-2025-61728 | archive/zip | High | 1.24.12+, 1.25.6+ |
| NR-560530 | CVE-2025-61729 | crypto/x509 | High | 1.24.11+, 1.25.5+ |
| NR-560529 | CVE-2026-25679 | net/url | High | No 1.24 fix, 1.25.8+ |
| NR-560528 | CVE-2026-32280 | crypto/x509 | High | No 1.24 fix, 1.25.9+ |
| NR-560527 | CVE-2026-32281 | crypto/x509 | High | No 1.24 fix, 1.25.9+ |
| NR-560526 | CVE-2026-32283 | crypto/tls | High | No 1.24 fix, 1.25.9+ |

## Rationale

**Go 1.25.9 is the minimal version that fixes all 9 CVEs.** The 4 most recent CVEs (CVE-2026-*) have no fixes available in the Go 1.24.x line, making a minor version upgrade necessary.

## Testing

- ✅ Build tested successfully with Go 1.25.9
- ✅ `go mod tidy` completed without errors
- ✅ Binary compilation verified

## JIRA Tickets

Closes: NR-560535, NR-560533, NR-560532, NR-560531, NR-560530, NR-560529, NR-560528, NR-560527, NR-560526