### PR TITLE
fix: bug for workflow

### DIFF
--- a/.github/workflows/release-function.yaml
+++ b/.github/workflows/release-function.yaml
@@ -12,6 +12,9 @@ on:
       - 'logs-function/**'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   build_docker_image:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
Adds an explicit `permissions` block to `.github/workflows/release-function.yaml`, which previously had none — leaving both jobs (`build_docker_image`, `push_docker_image`) to inherit the default (potentially broad) `GITHUB_TOKEN` scope.

## Change
- Added top-level `permissions: contents: read` to the workflow. Both jobs only checkout code and build/push a Docker image to an OCI registry via secrets — neither needs GitHub API write access.

## CodeQL Alerts Fixed
| Alert | Job | Link |
|---|---|---|
| #1 | `build_docker_image` | https://github.com/newrelic/oci-log-integration/security/code-scanning/1 |
| #2 | `push_docker_image` | https://github.com/newrelic/oci-log-integration/security/code-scanning/2 |

Rule: `actions/missing-workflow-permissions` (medium severity)

## JIRA
Closes: NR-560537

## Testing
- Validated YAML syntax
- No functional change to job behavior — `contents: read` is sufficient for checkout-only, non-GitHub-API steps